### PR TITLE
Fixes zip file xlsx cannot be opened

### DIFF
--- a/R/download_springer_table.R
+++ b/R/download_springer_table.R
@@ -18,7 +18,7 @@ download_springer_table <-
 
     if (lan == 'eng') {
 
-      books_list_url <- 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4/'
+      books_list_url <- 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v5/'
       GET(books_list_url, write_disk(tf <- tempfile(fileext = ".xlsx")))
       springer_table <- read_excel(tf) %>%
         clean_names()


### PR DESCRIPTION
The download was failing due to an old URL download link. Changed from v4 to v5 fixes the problem.
Closes #37 
Credits goes to @stm.